### PR TITLE
Hotfix I-000967 #97 : Se ha solucionado el incidente que había en itop

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/web/PetitionController.java
+++ b/src/main/java/org/springframework/samples/petclinic/web/PetitionController.java
@@ -74,15 +74,26 @@ public class PetitionController {
 	@GetMapping("/adoptions/{adoptionId}/petitions/new")
 	public String initAddPetition(@PathVariable("adoptionId") final int adoptionId, final ModelMap modelMap) {
 
-		final Petition petition = new Petition();
-		petition.setApplicant(this.ownerService.getPrincipal());
-		petition.setStatus(PetitionStatus.PENDIENTE);
 		final Adoption adoption = this.adoptionService.getById(adoptionId);
+		final Owner ow = this.ownerService.getPrincipal();
+		
+		//Esto sirve para comprobar que no hay peticiones previas del owner de principal a esta adopcion
+		if (adoption.getPetitions().stream().anyMatch(x->x.getApplicant().equals(ow))) {
+			
+			modelMap.put("adoptions", this.adoptionService.getAllAdoptions());
+			modelMap.put("message", "petitionalreadycreatederror");
+			return "adoptions/list";
+		} else {
+			final Petition petition = new Petition();
+			petition.setApplicant(this.ownerService.getPrincipal());
+			petition.setStatus(PetitionStatus.PENDIENTE);
+			
 
-		modelMap.put("petition", petition);
-		modelMap.put("adoption", adoption);
+			modelMap.put("petition", petition);
+			modelMap.put("adoption", adoption);
 
-		return "petitions/createOrUpdatePetitionForm";
+			return "petitions/createOrUpdatePetitionForm";
+		}
 	}
 
 	@PostMapping("/adoptions/{adoptionId}/petitions/new")

--- a/src/main/resources/messages/messages.properties
+++ b/src/main/resources/messages/messages.properties
@@ -135,6 +135,7 @@ updatepetition = Actualizar petici贸n
 declinePetition = Denegar petici贸n
 name = Nombre
 
+petitionalreadycreatederror = Ya has hecho una petici髇 para esta mascota
 createpetitionerror = Hubo un error creando la petici贸n
 createpetitionsuccess = La petici贸n se cre贸 correctamente
 editpetitionerror = Hubo un error editando la petici贸n

--- a/src/main/resources/messages/messages_en.properties
+++ b/src/main/resources/messages/messages_en.properties
@@ -141,6 +141,7 @@ updatepetition = Update petition
 declinePetition = Decline petition
 name = Name
 
+petitionalreadycreatederror = You have already done a petition for this pet
 createpetitionerror = There was an error creating the petition
 createpetitionsuccess = The petition was successfully created
 editpetitionerror = There was an error editing the petition

--- a/src/main/resources/messages/messages_es.properties
+++ b/src/main/resources/messages/messages_es.properties
@@ -135,6 +135,7 @@ updatepetition = Actualizar petici贸n
 declinePetition = Denegar petici贸n
 name = Nombre
 
+petitionalreadycreatederror = Ya has hecho una petici髇 para esta mascota
 createpetitionerror = Hubo un error creando la petici贸n
 createpetitionsuccess = La petici贸n se cre贸 correctamente
 editpetitionerror = Hubo un error editando la petici贸n


### PR DESCRIPTION
Este incidente consistía en que un owner podía hacer más de una petición
a una misma pet en adopción. Ahora salta un error que impide que se
creen más y en este error informa al usuario.